### PR TITLE
Ensure rest-day backfill runs per request

### DIFF
--- a/app_workout/tests.py
+++ b/app_workout/tests.py
@@ -1,3 +1,20 @@
 from django.test import TestCase
+from unittest.mock import patch
+from rest_framework.test import APIRequestFactory
 
-# Create your tests here.
+from .views import CardioLogsRecentView
+
+
+class CardioLogsRecentViewTests(TestCase):
+    def test_backfill_invoked_each_request(self):
+        """Ensure backfill_rest_days_if_gap is called when querying logs."""
+        factory = APIRequestFactory()
+        request = factory.get("/api/cardio/logs/")
+        view = CardioLogsRecentView()
+        view.request = request
+
+        with patch("app_workout.views.backfill_rest_days_if_gap") as mock_backfill:
+            # We only care that get_queryset triggers the helper; the actual
+            # queryset evaluation is secondary for this test.
+            view.get_queryset()
+            mock_backfill.assert_called_once()

--- a/app_workout/views.py
+++ b/app_workout/views.py
@@ -215,11 +215,19 @@ class CardioLogsRecentView(ListAPIView):
     GET /api/cardio/logs/?weeks=8
     Returns CardioDailyLog (+details) for the last N weeks (default 8).
     """
-    backfill_rest_days_if_gap()
     permission_classes = [permissions.AllowAny]
     serializer_class = CardioDailyLogSerializer
 
     def get_queryset(self):
+        # Ensure any large gap in logging is filled with "Rest" entries
+        # before fetching the recent logs. The previous implementation
+        # invoked this helper at import time, which meant the function
+        # executed once when the module was loaded rather than for each
+        # request. By calling it here, we run the backfill logic on
+        # demand per request and avoid unexpected side effects during
+        # module import.
+        backfill_rest_days_if_gap()
+
         weeks = int(self.request.query_params.get("weeks", 8))
         since = timezone.now() - timedelta(weeks=weeks)
         return (


### PR DESCRIPTION
## Summary
- Move `backfill_rest_days_if_gap` call into `CardioLogsRecentView.get_queryset` so it executes per request
- Add test verifying backfill helper is invoked when fetching recent cardio logs

## Testing
- `python manage.py test app_workout` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68a9eb0a77808332b2f5bbabb1517eba