### PR TITLE
Allow editing cardio log start time

### DIFF
--- a/app_workout/serializers.py
+++ b/app_workout/serializers.py
@@ -117,3 +117,9 @@ class CardioDailyLogSerializer(serializers.ModelSerializer):
             "minutes_elapsed",
             "details",
         ]
+
+
+class CardioDailyLogUpdateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = CardioDailyLog
+        fields = ["datetime_started"]


### PR DESCRIPTION
## Summary
- allow partial updates of cardio logs with new `datetime_started` serializer and patch endpoint
- add UI for editing cardio log start time in log details

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `python manage.py test` (fails: No module named 'django')

------
https://chatgpt.com/codex/tasks/task_e_68aa3bea91248332bb8170852b4b7847