### PR TITLE
refactor: move max mph update to client

### DIFF
--- a/app_workout/serializers.py
+++ b/app_workout/serializers.py
@@ -122,4 +122,4 @@ class CardioDailyLogSerializer(serializers.ModelSerializer):
 class CardioDailyLogUpdateSerializer(serializers.ModelSerializer):
     class Meta:
         model = CardioDailyLog
-        fields = ["datetime_started"]
+        fields = ["datetime_started", "max_mph"]

--- a/app_workout/signals.py
+++ b/app_workout/signals.py
@@ -71,7 +71,6 @@ def recompute_log_aggregates(log_id: int) -> None:
     have_minutes = False
     have_miles = False
 
-    max_mph = None
     mph_weighted_num = 0.0
     mph_weighted_den = 0.0
 
@@ -96,7 +95,6 @@ def recompute_log_aggregates(log_id: int) -> None:
             else:
                 mph_weighted_num += mph
                 mph_weighted_den += 1.0
-            max_mph = max(max_mph or mph, mph)
 
     avg_mph = (mph_weighted_num / mph_weighted_den) if mph_weighted_den > 0 else None
 
@@ -139,7 +137,6 @@ def recompute_log_aggregates(log_id: int) -> None:
         minutes_elapsed = 0.0
 
     CardioDailyLog.objects.filter(pk=log_id).update(
-        max_mph=max_mph,
         avg_mph=avg_mph,
         total_completed=total_completed,
         minutes_elapsed=minutes_elapsed,


### PR DESCRIPTION
## Summary
- stop computing and saving `max_mph` in cardio signals
- allow cardio daily log API to update `max_mph` from the client
- compute `max_mph` on the client and PATCH the log when details change

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab119bd8488332bdb31bcd52070efd