### PR TITLE
Avoid redundant PATCH when cardio log has no intervals

### DIFF
--- a/frontend/frontend_lifestyle/src/pages/LogDetailsPage.jsx
+++ b/frontend/frontend_lifestyle/src/pages/LogDetailsPage.jsx
@@ -85,6 +85,7 @@ export default function LogDetailsPage() {
   useEffect(() => {
     if (!data) return;
     const details = data.details || [];
+    if (details.length === 0) return; // avoid unnecessary PATCH when no intervals
     let max = null;
     for (const d of details) {
       const v = n(d.running_mph);


### PR DESCRIPTION
## Summary
- skip max_mph PATCH calls when a cardio log has no detail intervals

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68ab1f29f4e083328f7e14b2fff9ebe8