### PR TITLE
Add update endpoint for cardio log details

### DIFF
--- a/app_workout/serializers.py
+++ b/app_workout/serializers.py
@@ -60,6 +60,27 @@ class CardioDailyLogDetailCreateSerializer(serializers.ModelSerializer):
             "treadmill_time_seconds",
         ]
 
+
+class CardioDailyLogDetailUpdateSerializer(serializers.ModelSerializer):
+    """Allows partial updates for an existing interval."""
+
+    exercise_id = serializers.PrimaryKeyRelatedField(
+        source="exercise", queryset=CardioExercise.objects.all(), required=False
+    )
+
+    class Meta:
+        model = CardioDailyLogDetail
+        fields = [
+            "datetime",
+            "exercise_id",
+            "running_minutes",
+            "running_seconds",
+            "running_miles",
+            "running_mph",
+            "treadmill_time_minutes",
+            "treadmill_time_seconds",
+        ]
+
 class CardioDailyLogDetailSerializer(serializers.ModelSerializer):
     exercise = serializers.StringRelatedField()
     class Meta:

--- a/app_workout/tests.py
+++ b/app_workout/tests.py
@@ -11,6 +11,8 @@ from .models import (
     UnitType,
     SpeedName,
     CardioDailyLog,
+    CardioExercise,
+    CardioDailyLogDetail,
 )
 
 
@@ -64,3 +66,46 @@ class MaxMphUpdateTests(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.log.refresh_from_db()
         self.assertEqual(self.log.max_mph, 7.25)
+
+
+class CardioLogDetailUpdateTests(TestCase):
+    def setUp(self):
+        unit_type = UnitType.objects.create(name="Distance")
+        speed_name = SpeedName.objects.create(name="mph", speed_type="distance/time")
+        unit = CardioUnit.objects.create(
+            name="Miles",
+            unit_type=unit_type,
+            mround_numerator=1,
+            mround_denominator=1,
+            speed_name=speed_name,
+            mile_equiv_numerator=1,
+            mile_equiv_denominator=1,
+        )
+        routine = CardioRoutine.objects.create(name="R1")
+        workout = CardioWorkout.objects.create(
+            name="W1",
+            routine=routine,
+            unit=unit,
+            priority_order=1,
+            skip=False,
+            difficulty=1,
+        )
+        self.exercise = CardioExercise.objects.create(name="Run", unit=unit)
+        self.log = CardioDailyLog.objects.create(
+            datetime_started=timezone.now(),
+            workout=workout,
+        )
+        self.detail = CardioDailyLogDetail.objects.create(
+            log=self.log,
+            datetime=timezone.now(),
+            exercise=self.exercise,
+            running_minutes=5,
+        )
+        self.client = APIClient()
+
+    def test_patch_updates_interval(self):
+        url = f"/api/cardio/log/{self.log.id}/details/{self.detail.id}/"
+        resp = self.client.patch(url, {"running_minutes": 10}, format="json")
+        self.assertEqual(resp.status_code, 200)
+        self.detail.refresh_from_db()
+        self.assertEqual(self.detail.running_minutes, 10)

--- a/app_workout/urls.py
+++ b/app_workout/urls.py
@@ -4,7 +4,7 @@ from .views import (
     NextCardioView, RoutinesOrderedView, WorkoutsOrderedView, PredictWorkoutForRoutineView,
     LogCardioView, CardioExerciseListView,
     CardioLogsRecentView, CardioLogRetrieveView, CardioLogDetailsCreateView,
-    CardioLogDestroyView, CardioLogDetailDestroyView, CardioUnitListView
+    CardioLogDetailUpdateView, CardioLogDestroyView, CardioLogDetailDestroyView, CardioUnitListView
 )
 
 urlpatterns = [
@@ -16,6 +16,7 @@ urlpatterns = [
     path("cardio/logs/", CardioLogsRecentView.as_view(), name="cardio-logs-recent"),
     path("cardio/log/<int:pk>/", CardioLogRetrieveView.as_view(), name="cardio-log-retrieve"),
     path("cardio/log/<int:pk>/details/", CardioLogDetailsCreateView.as_view(), name="cardio-log-details-create"),
+    path("cardio/log/<int:pk>/details/<int:detail_id>/", CardioLogDetailUpdateView.as_view(), name="cardio-log-detail-update"),
 
     # NEW deletes
     path("cardio/log/<int:pk>/delete/", CardioLogDestroyView.as_view(), name="cardio-log-delete"),


### PR DESCRIPTION
## Summary
- support PATCH on `/api/cardio/log/<log_id>/details/<detail_id>/` by adding URL and view
- add `CardioDailyLogDetailUpdateSerializer` for partial interval updates
- test updating an interval detail

## Testing
- `python manage.py test` *(fails: No module named 'django')*
- `pip install django djangorestframework` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_68ab20e4293883329d648828b0a965d5