### PR TITLE
Remove outside-click dismissal for interval modal

### DIFF
--- a/frontend/frontend_lifestyle/src/components/ui/Modal.jsx
+++ b/frontend/frontend_lifestyle/src/components/ui/Modal.jsx
@@ -1,8 +1,7 @@
-export default function Modal({ open, onClose, children }) {
+export default function Modal({ open, children }) {
   if (!open) return null;
   return (
     <div
-      onClick={onClose}
       style={{
         position: "fixed",
         top: 0,
@@ -18,7 +17,6 @@ export default function Modal({ open, onClose, children }) {
       }}
     >
       <div
-        onClick={(e) => e.stopPropagation()}
         style={{
           background: "#fff",
           borderRadius: 12,

--- a/frontend/frontend_lifestyle/src/pages/LogDetailsPage.jsx
+++ b/frontend/frontend_lifestyle/src/pages/LogDetailsPage.jsx
@@ -561,7 +561,7 @@ const onChangeSpeedDisplay = (v) => {
 
             <div style={{ height: 12 }} />
             <button type="button" style={btnStyle} onClick={openModal} disabled={unitsApi.loading}>Add interval</button>
-            <Modal open={addModalOpen} onClose={closeModal}>
+            <Modal open={addModalOpen}>
             <form onSubmit={submit}>
               <div style={{ display: "grid", gap: 8, gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))" }}>
 


### PR DESCRIPTION
## Summary
- keep interval modal open when clicking outside of it
- simplify Modal component API and usage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab327060cc83329d7d1f6b6a0e601d