### PR TITLE
Prefill cardio interval form with last values

### DIFF
--- a/app_workout/urls.py
+++ b/app_workout/urls.py
@@ -4,7 +4,8 @@ from .views import (
     NextCardioView, RoutinesOrderedView, WorkoutsOrderedView, PredictWorkoutForRoutineView,
     LogCardioView, CardioExerciseListView,
     CardioLogsRecentView, CardioLogRetrieveView, CardioLogDetailsCreateView,
-    CardioLogDetailUpdateView, CardioLogDestroyView, CardioLogDetailDestroyView, CardioUnitListView
+    CardioLogDetailUpdateView, CardioLogDestroyView, CardioLogDetailDestroyView, CardioUnitListView,
+    CardioLogLastIntervalView,
 )
 
 urlpatterns = [
@@ -17,6 +18,7 @@ urlpatterns = [
     path("cardio/log/<int:pk>/", CardioLogRetrieveView.as_view(), name="cardio-log-retrieve"),
     path("cardio/log/<int:pk>/details/", CardioLogDetailsCreateView.as_view(), name="cardio-log-details-create"),
     path("cardio/log/<int:pk>/details/<int:detail_id>/", CardioLogDetailUpdateView.as_view(), name="cardio-log-detail-update"),
+    path("cardio/log/<int:pk>/last-interval/", CardioLogLastIntervalView.as_view(), name="cardio-log-last-interval"),
 
     # NEW deletes
     path("cardio/log/<int:pk>/delete/", CardioLogDestroyView.as_view(), name="cardio-log-delete"),

--- a/frontend/frontend_lifestyle/src/pages/LogDetailsPage.jsx
+++ b/frontend/frontend_lifestyle/src/pages/LogDetailsPage.jsx
@@ -362,11 +362,27 @@ const onChangeSpeedDisplay = (v) => {
     }
   };
 
-  const openModal = () => {
+  const openModal = async () => {
     setEditingId(null);
-    setAddModalOpen(true);
-    setRow({ ...emptyRow, datetime: toIsoLocalNow() });
     setTmSync("run_to_tm");
+    let base = { ...emptyRow, datetime: toIsoLocalNow() };
+    try {
+      const res = await fetch(`${API_BASE}/api/cardio/log/${id}/last-interval/`);
+      if (res.ok) {
+        const d = await res.json();
+        base = {
+          ...base,
+          running_minutes: d.running_minutes ?? "",
+          running_seconds: d.running_seconds ?? "",
+          running_miles: d.running_miles ?? "",
+          running_mph: d.running_mph ?? "",
+        };
+      }
+    } catch (err) {
+      console.error(err);
+    }
+    setRow(base);
+    setAddModalOpen(true);
   };
   const openEdit = (detail) => {
     setEditingId(detail.id);


### PR DESCRIPTION
## Summary
- add backend endpoint to fetch last cardio interval data with fallback
- prefill add-interval modal with previous interval defaults
- cover defaults logic with tests

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ab892ddc58833296a3d1662e3b9291