### PR TITLE
Add basic Strength frontend

### DIFF
--- a/frontend/frontend_lifestyle/src/App.jsx
+++ b/frontend/frontend_lifestyle/src/App.jsx
@@ -1,10 +1,12 @@
-import { BrowserRouter, Routes, Route, Link } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Link, useLocation } from "react-router-dom";
 import NextCard from "./components/NextCard";
 import RecentLogsCard from "./components/RecentLogsCard";
+import StrengthRecentLogsCard from "./components/StrengthRecentLogsCard";
 import LogDetailsPage from "./pages/LogDetailsPage";
+import StrengthLogDetailsPage from "./pages/StrengthLogDetailsPage";
 import { API_BASE } from "./lib/config";
 
-function Home() {
+function CardioHome() {
   return (
     <>
       <NextCard />
@@ -13,21 +15,43 @@ function Home() {
   );
 }
 
+function StrengthHome() {
+  return (
+    <>
+      <StrengthRecentLogsCard />
+    </>
+  );
+}
+
+function Header() {
+  const loc = useLocation();
+  const section = loc.pathname.startsWith("/strength") ? "Strength" : "Cardio";
+  return (
+    <header style={{ marginBottom: 16 }}>
+      <h1 style={{ margin: 0, fontSize: 24 }}>
+        <Link to="/" style={{ textDecoration: "none", color: "inherit" }}>Project Lifestyle — {section}</Link>
+      </h1>
+      <nav style={{ marginTop: 4 }}>
+        <Link to="/" style={{ marginRight: 12 }}>Cardio</Link>
+        <Link to="/strength">Strength</Link>
+      </nav>
+      <div style={{ opacity: 0.7 }}>DRF-backed predictions & queues</div>
+    </header>
+  );
+}
+
 export default function App() {
   return (
     <BrowserRouter>
       <div style={{ minHeight: "100vh", background: "#f8fafc", padding: 20, color: "#0f172a", fontFamily: "ui-sans-serif, -apple-system, Segoe UI, Roboto, Helvetica, Arial, Apple Color Emoji, Segoe UI Emoji" }}>
         <div style={{ maxWidth: 960, margin: "0 auto" }}>
-          <header style={{ marginBottom: 16 }}>
-            <h1 style={{ margin: 0, fontSize: 24 }}>
-              <Link to="/" style={{ textDecoration: "none", color: "inherit" }}>Project Lifestyle — Cardio</Link>
-            </h1>
-            <div style={{ opacity: 0.7 }}>DRF-backed predictions & queues</div>
-          </header>
+          <Header />
 
           <Routes>
-            <Route path="/" element={<Home />} />
+            <Route path="/" element={<CardioHome />} />
             <Route path="/logs/:id" element={<LogDetailsPage />} />
+            <Route path="/strength" element={<StrengthHome />} />
+            <Route path="/strength/logs/:id" element={<StrengthLogDetailsPage />} />
           </Routes>
 
           <footer style={{ marginTop: 24, fontSize: 12, opacity: 0.6 }}>

--- a/frontend/frontend_lifestyle/src/components/StrengthQuickLogCard.jsx
+++ b/frontend/frontend_lifestyle/src/components/StrengthQuickLogCard.jsx
@@ -1,0 +1,60 @@
+import { useState } from "react";
+import { API_BASE } from "../lib/config";
+import Card from "./ui/Card";
+
+const btnStyle = { border: "1px solid #e5e7eb", background: "#f9fafb", borderRadius: 8, padding: "6px 10px", cursor: "pointer" };
+
+export default function StrengthQuickLogCard({ onLogged }) {
+  const [routineId, setRoutineId] = useState("");
+  const [repGoal, setRepGoal] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitErr, setSubmitErr] = useState(null);
+
+  const submit = async (e) => {
+    e.preventDefault();
+    if (!routineId) return;
+    setSubmitting(true);
+    setSubmitErr(null);
+    try {
+      const payload = {
+        datetime_started: new Date().toISOString(),
+        routine_id: Number(routineId),
+        rep_goal: repGoal === "" ? null : Number(repGoal),
+      };
+      const res = await fetch(`${API_BASE}/api/strength/log/`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+      const created = await res.json();
+      onLogged?.(created);
+      setRepGoal("");
+    } catch (err) {
+      setSubmitErr(err);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Card title="Quick Log (Strength)" action={null}>
+      <form onSubmit={submit}>
+        <div style={{ display: "grid", gap: 12, gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))" }}>
+          <label>
+            <div>Routine ID</div>
+            <input type="number" value={routineId} onChange={(e) => setRoutineId(e.target.value)} />
+          </label>
+          <label>
+            <div>Rep Goal</div>
+            <input type="number" value={repGoal} onChange={(e) => setRepGoal(e.target.value)} />
+          </label>
+        </div>
+        <div style={{ marginTop: 12, display: "flex", alignItems: "center", gap: 8 }}>
+          <button type="submit" style={btnStyle} disabled={submitting || !routineId}>{submitting ? "Saving…" : "Save log"}</button>
+          {submitErr && <span style={{ color: "#b91c1c" }}>Error: {String(submitErr.message || submitErr)}</span>}
+        </div>
+      </form>
+    </Card>
+  );
+}

--- a/frontend/frontend_lifestyle/src/components/StrengthRecentLogsCard.jsx
+++ b/frontend/frontend_lifestyle/src/components/StrengthRecentLogsCard.jsx
@@ -1,0 +1,101 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import useApi from "../hooks/useApi";
+import { API_BASE } from "../lib/config";
+import Card from "./ui/Card";
+import StrengthQuickLogCard from "./StrengthQuickLogCard";
+
+const btnStyle = { border: "1px solid #e5e7eb", background: "#f9fafb", borderRadius: 8, padding: "6px 10px", cursor: "pointer" };
+const xBtn = {
+  border: "none",
+  background: "transparent",
+  color: "#b91c1c",
+  cursor: "pointer",
+  fontSize: 16,
+  lineHeight: 1,
+  padding: 4,
+};
+
+export default function StrengthRecentLogsCard() {
+  const { data, loading, error, refetch, setData } = useApi(`${API_BASE}/api/strength/logs/?weeks=8`, { deps: [] });
+  const rows = data || [];
+  const [deletingId, setDeletingId] = useState(null);
+  const [deleteErr, setDeleteErr] = useState(null);
+
+  const prepend = (row) => setData(prev => [row, ...(prev || [])]);
+
+  const handleDelete = async (id) => {
+    if (!confirm("Delete this daily log and all its sets?")) return;
+    setDeletingId(id);
+    setDeleteErr(null);
+    try {
+      const res = await fetch(`${API_BASE}/api/strength/log/${id}/delete/`, { method: "DELETE" });
+      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+      setData(prev => (prev || []).filter(r => r.id !== id));
+    } catch (e) {
+      setDeleteErr(e);
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  return (
+    <>
+      <StrengthQuickLogCard onLogged={(created) => { prepend(created); refetch(); }} />
+
+      <Card title="Recent Strength (8 weeks)" action={<button onClick={refetch} style={btnStyle}>Refresh</button>}>
+        {loading && <div>Loading…</div>}
+        {error && <div style={{ color: "#b91c1c" }}>Error: {String(error.message || error)}</div>}
+        {deleteErr && <div style={{ color: "#b91c1c", marginBottom: 8 }}>Delete error: {String(deleteErr.message || deleteErr)}</div>}
+
+        {!loading && !error && (
+          <div style={{ marginInline: "calc(50% - 50vw)", background: "white" }}>
+            <table style={{ width: "100vw", borderCollapse: "collapse" }}>
+              <thead>
+                <tr style={{ textAlign: "left", borderBottom: "1px solid #e5e7eb" }}>
+                  <th style={{ padding: 6, width: 36 }} aria-label="Delete column"></th>
+                  <th style={{ padding: 6 }}>Date</th>
+                  <th style={{ padding: 6 }}>Routine</th>
+                  <th style={{ padding: 6 }}>Rep Goal</th>
+                  <th style={{ padding: 6 }}>Total Reps</th>
+                  <th style={{ padding: 6 }}>Max Reps</th>
+                  <th style={{ padding: 6 }}>Max Weight</th>
+                  <th style={{ padding: 6 }}>Minutes</th>
+                  <th style={{ padding: 6 }}>Details</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((r) => (
+                  <tr key={r.id} style={{ borderTop: "1px solid #f3f4f6" }}>
+                    <td style={{ padding: 6, verticalAlign: "top" }}>
+                      <button
+                        type="button"
+                        style={xBtn}
+                        aria-label={`Delete log ${r.id}`}
+                        title="Delete log"
+                        onClick={() => handleDelete(r.id)}
+                        disabled={deletingId === r.id}
+                      >
+                        {deletingId === r.id ? "…" : "✕"}
+                      </button>
+                    </td>
+                    <td style={{ padding: 8 }}>{new Date(r.datetime_started).toLocaleString()}</td>
+                    <td style={{ padding: 8 }}>{r.routine?.name || "—"}</td>
+                    <td style={{ padding: 8 }}>{r.rep_goal ?? "—"}</td>
+                    <td style={{ padding: 8 }}>{r.total_reps_completed ?? "—"}</td>
+                    <td style={{ padding: 8 }}>{r.max_reps ?? "—"}</td>
+                    <td style={{ padding: 8 }}>{r.max_weight ?? "—"}</td>
+                    <td style={{ padding: 8 }}>{r.minutes_elapsed ?? "—"}</td>
+                    <td style={{ padding: 8 }}>
+                      <Link to={`/strength/logs/${r.id}`}>details</Link>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+    </>
+  );
+}

--- a/frontend/frontend_lifestyle/src/pages/StrengthLogDetailsPage.jsx
+++ b/frontend/frontend_lifestyle/src/pages/StrengthLogDetailsPage.jsx
@@ -1,0 +1,51 @@
+import { useParams } from "react-router-dom";
+import useApi from "../hooks/useApi";
+import { API_BASE } from "../lib/config";
+import Card from "../components/ui/Card";
+
+const btnStyle = { border: "1px solid #e5e7eb", background: "#f9fafb", borderRadius: 8, padding: "6px 10px", cursor: "pointer" };
+
+export default function StrengthLogDetailsPage() {
+  const { id } = useParams();
+  const { data, loading, error, refetch } = useApi(`${API_BASE}/api/strength/log/${id}/`, { deps: [id] });
+
+  return (
+    <Card title={`Strength Log ${id}`} action={<button onClick={refetch} style={btnStyle}>Refresh</button>}>
+      {loading && <div>Loading…</div>}
+      {error && <div style={{ color: "#b91c1c" }}>Error: {String(error.message || error)}</div>}
+      {!loading && !error && data && (
+        <>
+          <div style={{ marginBottom: 12 }}>
+            <div><strong>Started:</strong> {new Date(data.datetime_started).toLocaleString()}</div>
+            <div><strong>Routine:</strong> {data.routine?.name || "—"}</div>
+            <div><strong>Rep goal:</strong> {data.rep_goal ?? "—"}</div>
+            <div><strong>Total reps:</strong> {data.total_reps_completed ?? "—"}</div>
+            <div><strong>Max reps:</strong> {data.max_reps ?? "—"}</div>
+            <div><strong>Max weight:</strong> {data.max_weight ?? "—"}</div>
+            <div><strong>Minutes:</strong> {data.minutes_elapsed ?? "—"}</div>
+          </div>
+          <table style={{ borderCollapse: "collapse" }}>
+            <thead>
+              <tr style={{ textAlign: "left", borderBottom: "1px solid #e5e7eb" }}>
+                <th style={{ padding: 6 }}>Time</th>
+                <th style={{ padding: 6 }}>Exercise</th>
+                <th style={{ padding: 6 }}>Reps</th>
+                <th style={{ padding: 6 }}>Weight</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(data.details || []).map(d => (
+                <tr key={d.id} style={{ borderTop: "1px solid #f3f4f6" }}>
+                  <td style={{ padding: 8 }}>{new Date(d.datetime).toLocaleString()}</td>
+                  <td style={{ padding: 8 }}>{d.exercise || "—"}</td>
+                  <td style={{ padding: 8 }}>{d.reps ?? "—"}</td>
+                  <td style={{ padding: 8 }}>{d.weight ?? "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      )}
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- add Strength logging components (quick log, recent logs, details page)
- wire up navigation and routes for Strength

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab9046286483329c17a17852a33d6f