### PR TITLE
Add Next Strength prediction logic

### DIFF
--- a/app_workout/tests.py
+++ b/app_workout/tests.py
@@ -13,6 +13,8 @@ from .models import (
     CardioDailyLog,
     CardioExercise,
     CardioDailyLogDetail,
+    StrengthRoutine,
+    StrengthDailyLog,
 )
 
 
@@ -184,3 +186,18 @@ class LastIntervalDefaultsTests(TestCase):
         data = resp.json()
         self.assertEqual(data["running_minutes"], 0)
         self.assertEqual(data["running_miles"], 0)
+
+
+class NextStrengthViewTests(TestCase):
+    def setUp(self):
+        self.r1 = StrengthRoutine.objects.create(name="R1", hundred_points_reps=100, hundred_points_weight=100)
+        self.r2 = StrengthRoutine.objects.create(name="R2", hundred_points_reps=100, hundred_points_weight=100)
+        StrengthDailyLog.objects.create(datetime_started=timezone.now(), routine=self.r1)
+        self.client = APIClient()
+
+    def test_returns_least_recent_routine(self):
+        resp = self.client.get("/api/strength/next/")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["next_routine"]["name"], "R2")
+        self.assertEqual(data["routine_list"][-1]["name"], "R2")

--- a/app_workout/urls.py
+++ b/app_workout/urls.py
@@ -2,6 +2,7 @@
 from django.urls import path
 from .views import (
     NextCardioView,
+    NextStrengthView,
     RoutinesOrderedView,
     WorkoutsOrderedView,
     PredictWorkoutForRoutineView,
@@ -28,6 +29,7 @@ from .views import (
 
 urlpatterns = [
     path("cardio/next/", NextCardioView.as_view(), name="cardio-next"),
+    path("strength/next/", NextStrengthView.as_view(), name="strength-next"),
     path("cardio/routines-ordered/", RoutinesOrderedView.as_view(), name="cardio-routines-ordered"),
     path("cardio/workouts-ordered/", WorkoutsOrderedView.as_view(), name="cardio-workouts-ordered"),
     path("cardio/predict-workout/", PredictWorkoutForRoutineView.as_view(), name="cardio-predict-workout"),

--- a/app_workout/views.py
+++ b/app_workout/views.py
@@ -31,6 +31,7 @@ from .serializers import (
     StrengthDailyLogDetailCreateSerializer,
     StrengthDailyLogDetailUpdateSerializer,
     StrengthDailyLogDetailSerializer,
+    StrengthRoutineSerializer,
 )
 from .services import (
     predict_next_cardio_routine,
@@ -38,7 +39,8 @@ from .services import (
     get_routines_ordered_by_last_completed,
     get_workouts_for_routine_ordered_by_last_completed,
     get_next_progression_for_workout,
-    get_next_cardio_workout, backfill_rest_days_if_gap
+    get_next_cardio_workout, backfill_rest_days_if_gap,
+    get_next_strength_routine,
 )
 from rest_framework import serializers
 from rest_framework.generics import ListAPIView
@@ -105,6 +107,22 @@ class NextCardioView(APIView):
             "next_workout": CardioWorkoutSerializer(next_workout).data if next_workout else None,
             "next_progression": CardioProgressionSerializer(next_progression).data if next_progression else None,
             "workout_list": CardioWorkoutSerializer(workout_list, many=True).data,
+        }
+        return Response(payload, status=status.HTTP_200_OK)
+
+
+class NextStrengthView(APIView):
+    """
+    GET /api/strength/next/
+    Returns: { next_routine, routine_list }
+    """
+    permission_classes = [permissions.AllowAny]
+
+    def get(self, request, *args, **kwargs):
+        next_routine, routine_list = get_next_strength_routine()
+        payload: Dict[str, Any] = {
+            "next_routine": StrengthRoutineSerializer(next_routine).data if next_routine else None,
+            "routine_list": StrengthRoutineSerializer(routine_list, many=True).data,
         }
         return Response(payload, status=status.HTTP_200_OK)
 


### PR DESCRIPTION
## Summary
- add service functions to predict and list next Strength routine
- expose `/api/strength/next/` endpoint to deliver upcoming routine suggestions
- cover new logic with test for least-recent strength routine selection

## Testing
- `python manage.py test` *(fails: No module named 'django')*
- `pip install django djangorestframework` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_68ab91f5f8688332b70a3c4a41346703