### PR TITLE
Add Next Strength card to frontend

### DIFF
--- a/frontend/frontend_lifestyle/src/App.jsx
+++ b/frontend/frontend_lifestyle/src/App.jsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, Link, useLocation } from "react-router-dom";
 import NextCard from "./components/NextCard";
 import RecentLogsCard from "./components/RecentLogsCard";
+import StrengthNextCard from "./components/StrengthNextCard";
 import StrengthRecentLogsCard from "./components/StrengthRecentLogsCard";
 import LogDetailsPage from "./pages/LogDetailsPage";
 import StrengthLogDetailsPage from "./pages/StrengthLogDetailsPage";
@@ -18,6 +19,7 @@ function CardioHome() {
 function StrengthHome() {
   return (
     <>
+      <StrengthNextCard />
       <StrengthRecentLogsCard />
     </>
   );

--- a/frontend/frontend_lifestyle/src/components/StrengthNextCard.jsx
+++ b/frontend/frontend_lifestyle/src/components/StrengthNextCard.jsx
@@ -1,0 +1,36 @@
+import useApi from "../hooks/useApi";
+import { API_BASE } from "../lib/config";
+import Card from "./ui/Card";
+import Pill from "./ui/Pill";
+
+const btnStyle = { border: "1px solid #e5e7eb", background: "#f9fafb", borderRadius: 8, padding: "6px 10px", cursor: "pointer" };
+
+export default function StrengthNextCard() {
+  const { data, loading, error, refetch } = useApi(`${API_BASE}/api/strength/next/`, { deps: [] });
+  const nextRoutine = data?.next_routine ?? null;
+  const routineList = data?.routine_list ?? [];
+
+  return (
+    <Card title="Next Strength" action={<button onClick={refetch} style={btnStyle}>Refresh</button>}>
+      {loading && <div>Loading…</div>}
+      {error && <div style={{ color: "#b91c1c" }}>Error: {String(error.message || error)}</div>}
+      {!loading && !error && (
+        <>
+          <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 12 }}>
+            <Pill>Predicted</Pill>
+            <div style={{ fontSize: 16, fontWeight: 600 }}>{nextRoutine ? nextRoutine.name : "—"}</div>
+          </div>
+          <div style={{ fontWeight: 600, marginBottom: 6 }}>Queue</div>
+          <ol style={{ margin: 0, paddingInlineStart: 18 }}>
+            {routineList.map((r, i) => (
+              <li key={`${r.id}-${i}`} style={{ padding: "4px 0" }}>
+                {r.name}
+                {nextRoutine && r.id === nextRoutine.id ? <span style={{ marginLeft: 8 }}><Pill>next</Pill></span> : null}
+              </li>
+            ))}
+          </ol>
+        </>
+      )}
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- add StrengthNextCard component to display next strength routine and queue
- show Next Strength on strength home page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `python manage.py test` (fails: Couldn't import Django)


------
https://chatgpt.com/codex/tasks/task_e_68ab9744f8708332b7dcf996990942db