### PR TITLE
Filter strength routine ordering by rep goal completion

### DIFF
--- a/app_workout/services.py
+++ b/app_workout/services.py
@@ -562,6 +562,8 @@ def get_strength_routines_ordered_by_last_completed(
     last_dt_subq = Subquery(
         StrengthDailyLog.objects
         .filter(routine=OuterRef("pk"))
+        .exclude(rep_goal__isnull=True)
+        .filter(total_reps_completed__gte=F("rep_goal"))
         .order_by("-datetime_started")
         .values("datetime_started")[:1],
         output_field=DateTimeField(),


### PR DESCRIPTION
## Summary
- Only consider strength logs that met their rep goal when ordering routines for prediction

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_68abafe56d4c83328210348b5bd5632e