### PR TITLE
Use Vw_Strength_Progression for strength goals

### DIFF
--- a/app_workout/serializers.py
+++ b/app_workout/serializers.py
@@ -12,6 +12,7 @@ from .models import (
     StrengthExercise,
     StrengthDailyLog,
     StrengthDailyLogDetail,
+    VwStrengthProgression,
 )
 from .signals import recompute_log_aggregates, recompute_strength_log_aggregates
 
@@ -194,6 +195,20 @@ class StrengthRoutineSerializer(serializers.ModelSerializer):
     class Meta:
         model = StrengthRoutine
         fields = ["id", "name", "hundred_points_reps", "hundred_points_weight"]
+
+
+class StrengthProgressionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = VwStrengthProgression
+        fields = [
+            "id",
+            "progression_order",
+            "routine_name",
+            "current_max",
+            "training_set",
+            "daily_volume",
+            "weekly_volume",
+        ]
 
 
 class StrengthDailyLogCreateSerializer(serializers.ModelSerializer):

--- a/app_workout/tests.py
+++ b/app_workout/tests.py
@@ -15,6 +15,7 @@ from .models import (
     CardioDailyLogDetail,
     StrengthRoutine,
     StrengthDailyLog,
+    VwStrengthProgression,
 )
 
 
@@ -193,6 +194,12 @@ class NextStrengthViewTests(TestCase):
         self.r1 = StrengthRoutine.objects.create(name="R1", hundred_points_reps=100, hundred_points_weight=100)
         self.r2 = StrengthRoutine.objects.create(name="R2", hundred_points_reps=100, hundred_points_weight=100)
         StrengthDailyLog.objects.create(datetime_started=timezone.now(), routine=self.r1)
+        VwStrengthProgression.objects.create(
+            id=1, progression_order=1, routine_name="R1", current_max=1, training_set=1, daily_volume=50, weekly_volume=100
+        )
+        VwStrengthProgression.objects.create(
+            id=2, progression_order=1, routine_name="R2", current_max=1, training_set=1, daily_volume=60, weekly_volume=120
+        )
         self.client = APIClient()
 
     def test_returns_least_recent_routine(self):
@@ -201,3 +208,4 @@ class NextStrengthViewTests(TestCase):
         data = resp.json()
         self.assertEqual(data["next_routine"]["name"], "R2")
         self.assertEqual(data["routine_list"][-1]["name"], "R2")
+        self.assertEqual(data["next_goal"]["daily_volume"], 60)

--- a/app_workout/views.py
+++ b/app_workout/views.py
@@ -32,6 +32,7 @@ from .serializers import (
     StrengthDailyLogDetailUpdateSerializer,
     StrengthDailyLogDetailSerializer,
     StrengthRoutineSerializer,
+    StrengthProgressionSerializer,
 )
 from .services import (
     predict_next_cardio_routine,
@@ -119,9 +120,10 @@ class NextStrengthView(APIView):
     permission_classes = [permissions.AllowAny]
 
     def get(self, request, *args, **kwargs):
-        next_routine, routine_list = get_next_strength_routine()
+        next_routine, next_goal, routine_list = get_next_strength_routine()
         payload: Dict[str, Any] = {
             "next_routine": StrengthRoutineSerializer(next_routine).data if next_routine else None,
+            "next_goal": StrengthProgressionSerializer(next_goal).data if next_goal else None,
             "routine_list": StrengthRoutineSerializer(routine_list, many=True).data,
         }
         return Response(payload, status=status.HTTP_200_OK)

--- a/frontend/frontend_lifestyle/src/components/StrengthNextCard.jsx
+++ b/frontend/frontend_lifestyle/src/components/StrengthNextCard.jsx
@@ -2,12 +2,14 @@ import useApi from "../hooks/useApi";
 import { API_BASE } from "../lib/config";
 import Card from "./ui/Card";
 import Pill from "./ui/Pill";
+import Row from "./ui/Row";
 
 const btnStyle = { border: "1px solid #e5e7eb", background: "#f9fafb", borderRadius: 8, padding: "6px 10px", cursor: "pointer" };
 
 export default function StrengthNextCard() {
   const { data, loading, error, refetch } = useApi(`${API_BASE}/api/strength/next/`, { deps: [] });
   const nextRoutine = data?.next_routine ?? null;
+  const nextGoal = data?.next_goal ?? null;
   const routineList = data?.routine_list ?? [];
 
   return (
@@ -20,6 +22,8 @@ export default function StrengthNextCard() {
             <Pill>Predicted</Pill>
             <div style={{ fontSize: 16, fontWeight: 600 }}>{nextRoutine ? nextRoutine.name : "—"}</div>
           </div>
+          <Row left={<strong>Next goal</strong>} right={nextGoal ? nextGoal.daily_volume : "—"} />
+          <div style={{ height: 8 }} />
           <div style={{ fontWeight: 600, marginBottom: 6 }}>Queue</div>
           <ol style={{ margin: 0, paddingInlineStart: 18 }}>
             {routineList.map((r, i) => (

--- a/frontend/frontend_lifestyle/src/components/StrengthQuickLogCard.jsx
+++ b/frontend/frontend_lifestyle/src/components/StrengthQuickLogCard.jsx
@@ -9,7 +9,7 @@ export default function StrengthQuickLogCard({ onLogged }) {
   const { data: nextData, loading } = useApi(`${API_BASE}/api/strength/next/`, { deps: [] });
   const predictedRoutine = nextData?.next_routine ?? null;
   const routineList = nextData?.routine_list ?? [];
-  const predictedRepGoal = predictedRoutine?.hundred_points_reps ?? "";
+  const predictedGoal = nextData?.next_goal?.daily_volume ?? "";
 
   const [routineId, setRoutineId] = useState(null);
   const [repGoal, setRepGoal] = useState("");
@@ -18,8 +18,8 @@ export default function StrengthQuickLogCard({ onLogged }) {
 
   useEffect(() => {
     if (predictedRoutine?.id) setRoutineId(predictedRoutine.id);
-    if (predictedRepGoal !== "") setRepGoal(String(predictedRepGoal));
-  }, [predictedRoutine?.id, predictedRepGoal]);
+    if (predictedGoal !== "") setRepGoal(String(predictedGoal));
+  }, [predictedRoutine?.id, predictedGoal]);
 
   const submit = async (e) => {
     e.preventDefault();
@@ -40,7 +40,7 @@ export default function StrengthQuickLogCard({ onLogged }) {
       if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
       const created = await res.json();
       onLogged?.(created);
-      if (predictedRepGoal !== "") setRepGoal(String(predictedRepGoal));
+      if (predictedGoal !== "") setRepGoal(String(predictedGoal));
     } catch (err) {
       setSubmitErr(err);
     } finally {
@@ -74,7 +74,7 @@ export default function StrengthQuickLogCard({ onLogged }) {
                 type="number"
                 value={repGoal}
                 onChange={(e) => setRepGoal(e.target.value)}
-                placeholder={predictedRepGoal !== "" ? String(predictedRepGoal) : ""}
+                placeholder={predictedGoal !== "" ? String(predictedGoal) : ""}
               />
             </label>
           </div>


### PR DESCRIPTION
## Summary
- compute next strength goal from `Vw_Strength_Progression` and expose via API
- show daily volume goal in strength components
- cover strength goal retrieval with tests

## Testing
- `python manage.py test` *(fails: No module named 'django')*
- `pip install django djangorestframework` *(fails: Could not find a version that satisfies the requirement django)*
- `npm --prefix frontend/frontend_lifestyle test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68abb2f8840c83329ccd287a7e414a22