### PR TITLE
Delay quick log predictions until logs loaded

### DIFF
--- a/frontend/frontend_lifestyle/src/components/QuickLogCard.jsx
+++ b/frontend/frontend_lifestyle/src/components/QuickLogCard.jsx
@@ -5,8 +5,8 @@ import Card from "./ui/Card";
 
 const btnStyle = { border: "1px solid #e5e7eb", background: "#f9fafb", borderRadius: 8, padding: "6px 10px", cursor: "pointer" };
 
-export default function QuickLogCard({ onLogged }) {
-  const { data: nextData, loading } = useApi(`${API_BASE}/api/cardio/next/`, { deps: [] });
+export default function QuickLogCard({ onLogged, ready = true }) {
+  const { data: nextData, loading } = useApi(`${API_BASE}/api/cardio/next/`, { deps: [ready], skip: !ready });
 
   const predictedWorkout = nextData?.next_workout ?? null;
   const predictedGoal = nextData?.next_progression?.progression ?? "";

--- a/frontend/frontend_lifestyle/src/components/RecentLogsCard.jsx
+++ b/frontend/frontend_lifestyle/src/components/RecentLogsCard.jsx
@@ -42,7 +42,7 @@ export default function RecentLogsCard() {
 
   return (
     <>
-      <QuickLogCard onLogged={(created) => { prepend(created); refetch(); }} />
+      <QuickLogCard ready={!loading} onLogged={(created) => { prepend(created); refetch(); }} />
 
       <Card title="Recent Cardio (8 weeks)" action={<button onClick={refetch} style={btnStyle}>Refresh</button>}>
         {loading && <div>Loading…</div>}

--- a/frontend/frontend_lifestyle/src/components/StrengthQuickLogCard.jsx
+++ b/frontend/frontend_lifestyle/src/components/StrengthQuickLogCard.jsx
@@ -5,8 +5,8 @@ import Card from "./ui/Card";
 
 const btnStyle = { border: "1px solid #e5e7eb", background: "#f9fafb", borderRadius: 8, padding: "6px 10px", cursor: "pointer" };
 
-export default function StrengthQuickLogCard({ onLogged }) {
-  const { data: nextData, loading } = useApi(`${API_BASE}/api/strength/next/`, { deps: [] });
+export default function StrengthQuickLogCard({ onLogged, ready = true }) {
+  const { data: nextData, loading } = useApi(`${API_BASE}/api/strength/next/`, { deps: [ready], skip: !ready });
   const predictedRoutine = nextData?.next_routine ?? null;
   const routineList = nextData?.routine_list ?? [];
   const predictedGoal = nextData?.next_goal?.daily_volume ?? "";

--- a/frontend/frontend_lifestyle/src/components/StrengthRecentLogsCard.jsx
+++ b/frontend/frontend_lifestyle/src/components/StrengthRecentLogsCard.jsx
@@ -41,7 +41,7 @@ export default function StrengthRecentLogsCard() {
 
   return (
     <>
-      <StrengthQuickLogCard onLogged={(created) => { prepend(created); refetch(); }} />
+      <StrengthQuickLogCard ready={!loading} onLogged={(created) => { prepend(created); refetch(); }} />
 
       <Card title="Recent Strength (8 weeks)" action={<button onClick={refetch} style={btnStyle}>Refresh</button>}>
         {loading && <div>Loading…</div>}


### PR DESCRIPTION
## Summary
- trigger cardio and strength quick log prediction API calls only after corresponding recent logs fetches

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abbb7ca3b483329ed48d300cab9788