### PR TITLE
Allow optional fields when creating strength logs

### DIFF
--- a/app_workout/serializers.py
+++ b/app_workout/serializers.py
@@ -229,6 +229,13 @@ class StrengthDailyLogCreateSerializer(serializers.ModelSerializer):
             "minutes_elapsed",
             "details",
         ]
+        extra_kwargs = {
+            "rep_goal": {"required": False, "allow_null": True},
+            "total_reps_completed": {"required": False, "allow_null": True},
+            "max_reps": {"required": False, "allow_null": True},
+            "max_weight": {"required": False, "allow_null": True},
+            "minutes_elapsed": {"required": False, "allow_null": True},
+        }
 
     def create(self, validated_data):
         details_data = validated_data.pop("details", [])


### PR DESCRIPTION
## Summary
- make StrengthDailyLogCreateSerializer allow nullable optional fields

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68aca4f6b5c883329b5965ccab6ec4fa