### PR TITLE
Allow fractional rep goal for strength log

### DIFF
--- a/app_workout/serializers.py
+++ b/app_workout/serializers.py
@@ -215,6 +215,7 @@ class StrengthDailyLogCreateSerializer(serializers.ModelSerializer):
     routine_id = serializers.PrimaryKeyRelatedField(
         source="routine", queryset=StrengthRoutine.objects.all(), write_only=True
     )
+    rep_goal = serializers.FloatField(required=False, allow_null=True)
     details = StrengthDailyLogDetailCreateSerializer(many=True, required=False)
 
     class Meta:
@@ -230,12 +231,17 @@ class StrengthDailyLogCreateSerializer(serializers.ModelSerializer):
             "details",
         ]
         extra_kwargs = {
-            "rep_goal": {"required": False, "allow_null": True},
             "total_reps_completed": {"required": False, "allow_null": True},
             "max_reps": {"required": False, "allow_null": True},
             "max_weight": {"required": False, "allow_null": True},
             "minutes_elapsed": {"required": False, "allow_null": True},
         }
+
+    def validate_rep_goal(self, value):
+        """Allow floats from the client but store as an integer."""
+        if value is None:
+            return value
+        return int(value)
 
     def create(self, validated_data):
         details_data = validated_data.pop("details", [])

--- a/app_workout/tests.py
+++ b/app_workout/tests.py
@@ -209,3 +209,22 @@ class NextStrengthViewTests(TestCase):
         self.assertEqual(data["next_routine"]["name"], "R2")
         self.assertEqual(data["routine_list"][-1]["name"], "R2")
         self.assertEqual(data["next_goal"]["daily_volume"], 60)
+
+
+class StrengthLogCreateTests(TestCase):
+    def setUp(self):
+        self.routine = StrengthRoutine.objects.create(
+            name="R1", hundred_points_reps=100, hundred_points_weight=100
+        )
+        self.client = APIClient()
+
+    def test_accepts_float_rep_goal(self):
+        payload = {
+            "datetime_started": timezone.now().isoformat(),
+            "routine_id": self.routine.id,
+            "rep_goal": 399.75,
+        }
+        resp = self.client.post("/api/strength/log/", payload, format="json")
+        self.assertEqual(resp.status_code, 201)
+        log = StrengthDailyLog.objects.get(pk=resp.data["id"])
+        self.assertEqual(log.rep_goal, 399)


### PR DESCRIPTION
## Summary
- Let strength log API accept floating-point rep goals by converting to integers
- Test that posting a float rep goal succeeds and stores the rounded value

## Testing
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68acaa5b307c8332b9973311a1b87eb0