### PR TITLE
Use standard and extra weight in strength modal

### DIFF
--- a/app_workout/views.py
+++ b/app_workout/views.py
@@ -549,7 +549,7 @@ class StrengthLogDetailDestroyView(APIView):
 class StrengthExerciseSerializer(serializers.ModelSerializer):
     class Meta:
         model = StrengthExercise
-        fields = ["id", "name"]
+        fields = ["id", "name", "standard_weight"]
 
 
 class StrengthExerciseListView(ListAPIView):


### PR DESCRIPTION
## Summary
- expose `standard_weight` on strength exercises API
- split weight entry into standard and extra fields in strength modal
- compute final weight from standard plus extra for new and edited sets

## Testing
- `npm test` *(fails: Missing script "test")*
- `python manage.py test` *(fails: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68acb6104abc8332ac28909e353f6be3