### PR TITLE
Default strength modal to previous exercise only after multiple sets

### DIFF
--- a/frontend/frontend_lifestyle/src/pages/StrengthLogDetailsPage.jsx
+++ b/frontend/frontend_lifestyle/src/pages/StrengthLogDetailsPage.jsx
@@ -35,6 +35,7 @@ export default function StrengthLogDetailsPage() {
   const openModal = async () => {
     setEditingId(null);
     let base = { ...emptyRow, datetime: toIsoLocalNow() };
+    const detailCount = data?.details?.length ?? 0;
     try {
       const res = await fetch(`${API_BASE}/api/strength/log/${id}/last-set/`);
       if (res.ok) {
@@ -44,11 +45,13 @@ export default function StrengthLogDetailsPage() {
         const extra = d.weight != null && std !== "" ? d.weight - std : "";
         base = {
           ...base,
-          exercise_id: ex ? String(ex.id) : "",
           reps: d.reps ?? "",
           standard_weight: std === "" ? "" : String(std),
           extra_weight: extra === "" ? "" : String(extra),
         };
+        if (detailCount > 1) {
+          base.exercise_id = ex ? String(ex.id) : "";
+        }
       }
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
## Summary
- Only pre-fill the exercise in the Strength log modal with the last set's exercise when the log already has more than one set

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acbbcc07008332bc365927ea270fe0