### PR TITLE
Default strength add-set modal to last exercise

### DIFF
--- a/frontend/frontend_lifestyle/src/pages/StrengthLogDetailsPage.jsx
+++ b/frontend/frontend_lifestyle/src/pages/StrengthLogDetailsPage.jsx
@@ -49,7 +49,7 @@ export default function StrengthLogDetailsPage() {
           standard_weight: std === "" ? "" : String(std),
           extra_weight: extra === "" ? "" : String(extra),
         };
-        if (detailCount > 1) {
+        if (detailCount > 0) {
           base.exercise_id = ex ? String(ex.id) : "";
         }
       }


### PR DESCRIPTION
## Summary
- default exercise selection to most recent exercise when adding a strength set

## Testing
- `python -m pytest`
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acbd0208348332b858d852ea9d1660