### PR TITLE
Fix strength set modal exercise selection

### DIFF
--- a/app_workout/serializers.py
+++ b/app_workout/serializers.py
@@ -185,10 +185,13 @@ class StrengthDailyLogDetailUpdateSerializer(serializers.ModelSerializer):
 
 class StrengthDailyLogDetailSerializer(serializers.ModelSerializer):
     exercise = serializers.StringRelatedField()
+    exercise_id = serializers.PrimaryKeyRelatedField(
+        source="exercise", read_only=True
+    )
 
     class Meta:
         model = StrengthDailyLogDetail
-        fields = ["id", "datetime", "exercise", "reps", "weight"]
+        fields = ["id", "datetime", "exercise", "exercise_id", "reps", "weight"]
 
 
 class StrengthRoutineSerializer(serializers.ModelSerializer):

--- a/frontend/frontend_lifestyle/src/pages/StrengthLogDetailsPage.jsx
+++ b/frontend/frontend_lifestyle/src/pages/StrengthLogDetailsPage.jsx
@@ -40,7 +40,7 @@ export default function StrengthLogDetailsPage() {
       const res = await fetch(`${API_BASE}/api/strength/log/${id}/last-set/`);
       if (res.ok) {
         const d = await res.json();
-        const ex = (exApi.data || []).find(e => e.name === d.exercise);
+        const ex = (exApi.data || []).find(e => e.id === d.exercise_id);
         const std = ex ? ex.standard_weight ?? 0 : "";
         const extra = d.weight != null && std !== "" ? d.weight - std : "";
         base = {
@@ -50,7 +50,7 @@ export default function StrengthLogDetailsPage() {
           extra_weight: extra === "" ? "" : String(extra),
         };
         if (detailCount > 0) {
-          base.exercise_id = ex ? String(ex.id) : "";
+          base.exercise_id = d.exercise_id ? String(d.exercise_id) : "";
         }
       }
     } catch (err) {
@@ -61,12 +61,12 @@ export default function StrengthLogDetailsPage() {
   };
   const openEdit = (detail) => {
     setEditingId(detail.id);
-    const ex = (exApi.data || []).find(e => e.name === detail.exercise);
+    const ex = (exApi.data || []).find(e => e.id === detail.exercise_id);
     const std = ex ? ex.standard_weight ?? 0 : "";
     const extra = detail.weight != null && std !== "" ? detail.weight - std : "";
     setRow({
       datetime: toIsoLocal(detail.datetime),
-      exercise_id: ex ? String(ex.id) : "",
+      exercise_id: detail.exercise_id ? String(detail.exercise_id) : "",
       reps: detail.reps ?? "",
       standard_weight: std === "" ? "" : String(std),
       extra_weight: extra === "" ? "" : String(extra),


### PR DESCRIPTION
## Summary
- return exercise_id in strength log detail serializer
- default strength set modal to last used exercise when adding or editing

## Testing
- `npm run lint`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68acbe1f450883328e16c07f46185d32