### PR TITLE
Add progress bar with markers to strength log

### DIFF
--- a/frontend/frontend_lifestyle/src/components/ui/ProgressBar.jsx
+++ b/frontend/frontend_lifestyle/src/components/ui/ProgressBar.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+export default function ProgressBar({ value = 0, max = 0 }) {
+  const percent = max > 0 ? Math.min(value, max) / max : 0;
+  const quarterMarks = [0.25, 0.5, 0.75];
+  const seventhMarks = [1/7, 2/7, 3/7, 4/7, 5/7, 6/7];
+
+  return (
+    <div style={{ position: "relative", height: 12, background: "#e5e7eb", borderRadius: 4, overflow: "hidden" }}>
+      <div style={{ width: `${percent * 100}%`, height: "100%", background: "#3b82f6" }} />
+      {quarterMarks.map((m, i) => (
+        <div
+          key={`q-${i}`}
+          style={{ position: "absolute", left: `${m * 100}%`, top: 0, bottom: 0, width: 2, background: "#1d4ed8" }}
+        />
+      ))}
+      {seventhMarks.map((m, i) => (
+        <div
+          key={`s-${i}`}
+          style={{ position: "absolute", left: `${m * 100}%`, top: "25%", bottom: "25%", width: 2, background: "#16a34a" }}
+        />
+      ))}
+    </div>
+  );
+}
+

--- a/frontend/frontend_lifestyle/src/pages/StrengthLogDetailsPage.jsx
+++ b/frontend/frontend_lifestyle/src/pages/StrengthLogDetailsPage.jsx
@@ -4,6 +4,7 @@ import useApi from "../hooks/useApi";
 import { API_BASE } from "../lib/config";
 import Card from "../components/ui/Card";
 import Modal from "../components/ui/Modal";
+import ProgressBar from "../components/ui/ProgressBar";
 
 const btnStyle = { border: "1px solid #e5e7eb", background: "#f9fafb", borderRadius: 8, padding: "6px 10px", cursor: "pointer" };
 const xBtnInline = { border: "none", background: "transparent", color: "#b91c1c", cursor: "pointer", fontSize: 14, lineHeight: 1, padding: 2, marginLeft: 8 };
@@ -129,6 +130,19 @@ export default function StrengthLogDetailsPage() {
     }
   };
 
+  const repGoal = data?.rep_goal ?? null;
+  const totalReps = data?.total_reps_completed ?? null;
+  let remaining25 = null;
+  let remaining7 = null;
+  if (repGoal != null && repGoal > 0 && totalReps != null) {
+    const quarter = repGoal * 0.25;
+    const seventh = repGoal / 7;
+    const nextQuarter = Math.ceil(totalReps / quarter) * quarter;
+    const nextSeventh = Math.ceil(totalReps / seventh) * seventh;
+    remaining25 = Math.max(0, Math.ceil(nextQuarter - totalReps));
+    remaining7 = Math.max(0, Math.ceil(nextSeventh - totalReps));
+  }
+
   return (
     <Card title={`Strength Log ${id}`} action={<button onClick={refetch} style={btnStyle}>Refresh</button>}>
       {loading && <div>Loading…</div>}
@@ -141,6 +155,25 @@ export default function StrengthLogDetailsPage() {
             <div><strong>Routine:</strong> {data.routine?.name || "—"}</div>
             <div><strong>Rep goal:</strong> {data.rep_goal ?? "—"}</div>
             <div><strong>Total reps:</strong> {data.total_reps_completed ?? "—"}</div>
+            {repGoal != null && totalReps != null && repGoal > 0 && (
+              <div style={{ marginTop: 4 }}>
+                <ProgressBar value={totalReps} max={repGoal} />
+                <div style={{ display: "flex", gap: 16, fontSize: 12, marginTop: 4 }}>
+                  <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                    <span style={{ width: 2, height: 12, background: "#1d4ed8", display: "inline-block" }}></span>
+                    25%
+                  </div>
+                  <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                    <span style={{ width: 2, height: 6, background: "#16a34a", display: "inline-block" }}></span>
+                    1/7
+                  </div>
+                </div>
+                <div style={{ fontSize: 12, marginTop: 4 }}>
+                  <div>Remaining to next 25% marker: {remaining25}</div>
+                  <div>Remaining to next 1/7 marker: {remaining7}</div>
+                </div>
+              </div>
+            )}
             <div><strong>Max reps:</strong> {data.max_reps ?? "—"}</div>
             <div><strong>Max weight:</strong> {data.max_weight ?? "—"}</div>
             <div><strong>Minutes:</strong> {data.minutes_elapsed ?? "—"}</div>


### PR DESCRIPTION
## Summary
- show progress bar for total reps vs rep goal on strength log details
- mark progress bar every 25% and 1/7 with legend and remaining counts
- extract reusable ProgressBar component with visual markers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acc38746188332af65160460422b3a