### PR TITLE
Use weighted formula for max reps calculation

### DIFF
--- a/app_workout/migrations/0011_alter_strengthdailylog_max_reps.py
+++ b/app_workout/migrations/0011_alter_strengthdailylog_max_reps.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("app_workout", "0010_remove_strengthexercise_default_weight"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="strengthdailylog",
+            name="max_reps",
+            field=models.FloatField(blank=True, null=True),
+        ),
+    ]

--- a/app_workout/models.py
+++ b/app_workout/models.py
@@ -303,7 +303,7 @@ class StrengthDailyLog(models.Model):
     routine = models.ForeignKey(StrengthRoutine, on_delete=models.PROTECT, related_name="daily_logs")
     rep_goal = models.FloatField(null=True, blank=True)
     total_reps_completed = models.FloatField(null=True, blank=True)
-    max_reps = models.PositiveIntegerField(null=True, blank=True)
+    max_reps = models.FloatField(null=True, blank=True)
     max_weight = models.FloatField(null=True, blank=True)
     minutes_elapsed = models.FloatField(null=True, blank=True)
 

--- a/app_workout/signals.py
+++ b/app_workout/signals.py
@@ -140,7 +140,14 @@ def recompute_strength_log_aggregates(log_id: int) -> None:
         for d in details
         if d.reps is not None and d.weight is not None
     )
-    max_reps = max((d.reps for d in details if d.reps is not None), default=None)
+    max_reps = max(
+        (
+            (d.reps * d.weight) / log.routine.hundred_points_weight
+            for d in details
+            if d.reps is not None and d.weight is not None
+        ),
+        default=None,
+    )
     max_weight = max((d.weight for d in details if d.weight is not None), default=None)
     minutes_elapsed = 0.0
     if details:

--- a/app_workout/tests.py
+++ b/app_workout/tests.py
@@ -257,3 +257,28 @@ class StrengthAggregateTests(TestCase):
         )
         log.refresh_from_db()
         self.assertAlmostEqual(log.total_reps_completed, (5 * 100 + 3 * 150) / 200)
+
+    def test_max_reps_uses_weight_and_routine_factor(self):
+        routine = StrengthRoutine.objects.create(
+            name="R1", hundred_points_reps=100, hundred_points_weight=200
+        )
+        exercise = StrengthExercise.objects.create(name="E1", routine=routine)
+        log = StrengthDailyLog.objects.create(
+            datetime_started=timezone.now(), routine=routine
+        )
+        StrengthDailyLogDetail.objects.create(
+            log=log,
+            datetime=timezone.now(),
+            exercise=exercise,
+            reps=5,
+            weight=100,
+        )
+        StrengthDailyLogDetail.objects.create(
+            log=log,
+            datetime=timezone.now(),
+            exercise=exercise,
+            reps=3,
+            weight=250,
+        )
+        log.refresh_from_db()
+        self.assertAlmostEqual(log.max_reps, (3 * 250) / 200)


### PR DESCRIPTION
## Summary
- compute max reps using the weight-adjusted rep formula
- store max reps as a float to allow fractional values
- cover weighted max reps in tests

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django==4.2.7` *(fails: Could not find a version that satisfies the requirement due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68accb6f405483328f65609d4f326550