### PR TITLE
Handle unmatched history when predicting cardio routine

### DIFF
--- a/app_workout/services.py
+++ b/app_workout/services.py
@@ -137,11 +137,16 @@ def predict_next_cardio_routine(now=None) -> Optional[CardioRoutine]:
 
     if start_idx is None:
         last_routine_id = recent_pattern[-1]
-        # find the rightmost occurrence in repeated_plan
-        try:
-            last_pos = max(idx for idx, v in enumerate(repeated_plan) if v == last_routine_id)
-        except ValueError:
+        # find all occurrences in repeated_plan so we can handle a match at the end
+        positions = [idx for idx, v in enumerate(repeated_plan) if v == last_routine_id]
+        if not positions:
             return CardioRoutine.objects.get(pk=plan_ids[0])
+
+        last_pos = positions[-1]
+        if last_pos + 1 >= len(repeated_plan) and len(positions) > 1:
+            # If the last occurrence is at the very end, use the previous one
+            last_pos = positions[-2]
+
         next_id = repeated_plan[last_pos + 1] if last_pos + 1 < len(repeated_plan) else plan_ids[0]
         return CardioRoutine.objects.get(pk=next_id)
 

--- a/app_workout/tests.py
+++ b/app_workout/tests.py
@@ -105,6 +105,24 @@ class PredictNextRoutineTests(TestCase):
         next_routine = predict_next_cardio_routine(now=now)
         self.assertEqual(next_routine.name, "Rest")
 
+    def test_unmatched_history_still_returns_rest(self):
+        now = timezone.now()
+        CardioDailyLog.objects.create(
+            datetime_started=now - timedelta(days=3),
+            workout=self.w5k,
+        )
+        CardioDailyLog.objects.create(
+            datetime_started=now - timedelta(days=2),
+            workout=self.wsprint,
+        )
+        CardioDailyLog.objects.create(
+            datetime_started=now - timedelta(hours=1),
+            workout=self.wsprint,
+        )
+
+        next_routine = predict_next_cardio_routine(now=now)
+        self.assertEqual(next_routine.name, "Rest")
+
 
 class MaxMphUpdateTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- prevent cardio routine predictor from skipping rest when recent log pattern isn't found
- cover unmatched history with a new test

## Testing
- `python manage.py test app_workout.tests.PredictNextRoutineTests -v 2` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68af0cb162648332b67bf086c8f71feb