### PR TITLE
Add cardio goal endpoint

### DIFF
--- a/app_workout/urls.py
+++ b/app_workout/urls.py
@@ -6,6 +6,7 @@ from .views import (
     RoutinesOrderedView,
     WorkoutsOrderedView,
     PredictWorkoutForRoutineView,
+    CardioMPHGoalView,
     LogCardioView,
     CardioExerciseListView,
     CardioLogsRecentView,
@@ -33,6 +34,7 @@ urlpatterns = [
     path("cardio/routines-ordered/", RoutinesOrderedView.as_view(), name="cardio-routines-ordered"),
     path("cardio/workouts-ordered/", WorkoutsOrderedView.as_view(), name="cardio-workouts-ordered"),
     path("cardio/predict-workout/", PredictWorkoutForRoutineView.as_view(), name="cardio-predict-workout"),
+    path("cardio/mph-goal/", CardioMPHGoalView.as_view(), name="cardio-mph-goal"),
 
     path("cardio/logs/", CardioLogsRecentView.as_view(), name="cardio-logs-recent"),
     path("cardio/log/<int:pk>/", CardioLogRetrieveView.as_view(), name="cardio-log-retrieve"),


### PR DESCRIPTION
## Summary
- add endpoint to compute cardio MPH goal and convert unit input to miles/time
- expose cardio goal endpoint in API URLs
- test conversions for time and distance units
- show MPH goal, miles, and time in Quick Log card and submit converted goal

## Testing
- `npm run lint`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68af2e7655648332ab306570d3666767