### PR TITLE
Override MPH goal value for Sprints cardio routine

### DIFF
--- a/app_workout/tests.py
+++ b/app_workout/tests.py
@@ -602,3 +602,25 @@ class MPHGoalEndpointTests(TestCase):
         self.assertAlmostEqual(resp.data["miles"], 0.497, places=3)
         self.assertEqual(resp.data["minutes"], 4)
         self.assertAlmostEqual(resp.data["seconds"], 58.258, places=3)
+
+    def test_sprints_overrides_value(self):
+        routine = CardioRoutine.objects.create(name="Sprints")
+        w_sprint = CardioWorkout.objects.create(
+            name="400s",
+            routine=routine,
+            unit=self.unit_400,
+            priority_order=1,
+            skip=False,
+            difficulty=1,
+        )
+        VwMPHGoal.objects.create(
+            id=w_sprint.id, name=w_sprint.name, difficulty=1, mph_goal=6.0
+        )
+        resp = self.client.get(
+            "/api/cardio/mph-goal/",
+            {"workout_id": w_sprint.id, "value": 5},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertAlmostEqual(resp.data["miles"], 0.249, places=3)
+        self.assertEqual(resp.data["minutes"], 2)
+        self.assertAlmostEqual(resp.data["seconds"], 29.129, places=3)

--- a/app_workout/views.py
+++ b/app_workout/views.py
@@ -226,8 +226,11 @@ class CardioMPHGoalView(APIView):
             )
 
         workout = get_object_or_404(
-            CardioWorkout.objects.select_related("unit", "unit__unit_type"), pk=wid
+            CardioWorkout.objects.select_related("unit", "unit__unit_type", "routine"),
+            pk=wid,
         )
+        if workout.routine.name.lower() == "sprints":
+            val = 1.0
         mph_goal_obj = get_object_or_404(VwMPHGoal, pk=wid)
         mph_goal = float(mph_goal_obj.mph_goal)
 


### PR DESCRIPTION
## Summary
- ensure cardio MPH goal endpoint always uses value 1 for Sprints routines
- test mph goal endpoint for Sprints workouts

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68af34297a6c8332a124b4e77c9a1670