### PR TITLE
Show cardio goal distance

### DIFF
--- a/app_workout/views.py
+++ b/app_workout/views.py
@@ -243,9 +243,11 @@ class CardioMPHGoalView(APIView):
         if unit_type == "time":
             minutes_total = val
             miles = mph_goal * (minutes_total / 60.0)
+            distance_payload = {"miles": round(miles, 3)}
         else:
             miles = val * miles_per_unit
             minutes_total = (miles / mph_goal) * 60.0 if mph_goal else 0.0
+            distance_payload = {"distance": round(val, 3)}
 
         minutes_int = int(minutes_total)
         seconds = round((minutes_total - minutes_int) * 60.0, 3)
@@ -253,7 +255,7 @@ class CardioMPHGoalView(APIView):
         return Response(
             {
                 "mph_goal": mph_goal,
-                "miles": round(miles, 3),
+                **distance_payload,
                 "minutes": minutes_int,
                 "seconds": seconds,
             },

--- a/frontend/frontend_lifestyle/src/components/QuickLogCard.jsx
+++ b/frontend/frontend_lifestyle/src/components/QuickLogCard.jsx
@@ -32,6 +32,14 @@ export default function QuickLogCard({ onLogged, ready = true }) {
   const [submitting, setSubmitting] = useState(false);
   const [submitErr, setSubmitErr] = useState(null);
 
+  const currentWorkout = useMemo(() => {
+    if (workoutId) {
+      const fromList = (workouts.data || []).find((w) => w.id === workoutId);
+      if (fromList) return fromList;
+    }
+    return predictedWorkout;
+  }, [workoutId, workouts.data, predictedWorkout]);
+
   useEffect(() => {
     if (!workoutId || goal === "") {
       setGoalInfo(null);
@@ -101,7 +109,13 @@ export default function QuickLogCard({ onLogged, ready = true }) {
           {goalInfo && (
             <div style={{ marginTop: 8, fontSize: "0.9rem", color: "#374151" }}>
               <div>MPH Goal: {goalInfo.mph_goal}</div>
-              <div>Miles: {goalInfo.miles}</div>
+              {currentWorkout?.unit?.unit_type === "time" ? (
+                <div>Miles: {goalInfo.miles}</div>
+              ) : (
+                <div>
+                  {currentWorkout?.unit?.name || "Distance"}: {goalInfo.distance}
+                </div>
+              )}
               <div>Time: {goalInfo.minutes}m {goalInfo.seconds}s</div>
             </div>
           )}


### PR DESCRIPTION
## Summary
- Return workout distance instead of miles for non-time units
- Display distance with proper unit in quick log card

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af3716b6cc8332aaee26992decc4b0