### PR TITLE
fix: log user goal instead of mph goal

### DIFF
--- a/frontend/frontend_lifestyle/src/components/QuickLogCard.jsx
+++ b/frontend/frontend_lifestyle/src/components/QuickLogCard.jsx
@@ -65,12 +65,7 @@ export default function QuickLogCard({ onLogged, ready = true }) {
       const payload = {
         datetime_started: new Date().toISOString(),
         workout_id: workoutId,
-        goal:
-          goalInfo && typeof goalInfo.mph_goal === "number"
-            ? goalInfo.mph_goal
-            : goal === ""
-              ? null
-              : Number(goal),
+        goal: goal === "" ? null : Number(goal),
       };
       const res = await fetch(`${API_BASE}/api/cardio/log/`, {
         method: "POST",


### PR DESCRIPTION
## Summary
- send user-entered goal in quick log payload instead of mph goal

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django djangorestframework` *(fails: Could not find a version that satisfies the requirement django)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af3b4ad61c8332a500eaf15d4431ef