### PR TITLE
Refresh MPH goal when Max MPH updates

### DIFF
--- a/frontend/frontend_lifestyle/src/pages/LogDetailsPage.jsx
+++ b/frontend/frontend_lifestyle/src/pages/LogDetailsPage.jsx
@@ -103,6 +103,7 @@ export default function LogDetailsPage() {
       if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
       await res.json();
       await refetch();
+      refreshMphGoal();
     } catch (err) {
       setUpdateMaxErr(err);
     } finally {
@@ -134,12 +135,13 @@ export default function LogDetailsPage() {
             body: JSON.stringify({ max_mph: autoMax }),
           });
           await refetch();
+          refreshMphGoal();
         } catch (err) {
           console.error(err);
         }
       })();
     }
-  }, [autoMax, data?.max_mph, id, refetch]);
+  }, [autoMax, data?.max_mph, id, refetch, refreshMphGoal]);
 
   // prevTM FIRST (used by others)
   const prevTM = useMemo(() => {


### PR DESCRIPTION
## Summary
- Refresh MPH goal whenever the Max MPH is manually saved
- Refresh MPH goal when auto-calculated Max MPH syncs to the backend

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af404609688332bcd326d3c4eadabb