### PR TITLE
Fix cardio quick log time unit display

### DIFF
--- a/frontend/frontend_lifestyle/src/components/QuickLogCard.jsx
+++ b/frontend/frontend_lifestyle/src/components/QuickLogCard.jsx
@@ -104,14 +104,16 @@ export default function QuickLogCard({ onLogged, ready = true }) {
           {goalInfo && (
             <div style={{ marginTop: 8, fontSize: "0.9rem", color: "#374151" }}>
               <div>MPH Goal: {goalInfo.mph_goal}</div>
-              {currentWorkout?.unit?.unit_type === "time" ? (
+              {currentWorkout?.unit?.unit_type?.toLowerCase() === "time" ? (
                 <div>Miles: {goalInfo.miles}</div>
               ) : (
                 <div>
                   {currentWorkout?.unit?.name || "Distance"}: {goalInfo.distance}
                 </div>
               )}
-              <div>Time: {goalInfo.minutes}m {goalInfo.seconds}s</div>
+              <div>
+                Time: {goalInfo.minutes} minutes{goalInfo.seconds ? ` ${goalInfo.seconds} seconds` : ""}
+              </div>
             </div>
           )}
           <div style={{ marginTop: 12, display: "flex", alignItems: "center", gap: 8 }}>

--- a/frontend/frontend_lifestyle/src/pages/LogDetailsPage.jsx
+++ b/frontend/frontend_lifestyle/src/pages/LogDetailsPage.jsx
@@ -553,7 +553,7 @@ const onChangeSpeedDisplay = (v) => {
                 mphGoalInfo ? (
                   <div style={{ textAlign: "right" }}>
                     <div>{mphGoalInfo.mph_goal}</div>
-                    {data.workout?.unit?.unit_type === "time" ? (
+                    {data.workout?.unit?.unit_type?.toLowerCase() === "time" ? (
                       <div style={{ fontSize: 12 }}>Miles: {mphGoalInfo.miles}</div>
                     ) : (
                       <div style={{ fontSize: 12 }}>
@@ -561,7 +561,7 @@ const onChangeSpeedDisplay = (v) => {
                       </div>
                     )}
                     <div style={{ fontSize: 12 }}>
-                      Time: {mphGoalInfo.minutes}m {mphGoalInfo.seconds}s
+                      Time: {mphGoalInfo.minutes} minutes{mphGoalInfo.seconds ? ` ${mphGoalInfo.seconds} seconds` : ""}
                     </div>
                   </div>
                 ) : (


### PR DESCRIPTION
## Summary
- ensure time-based cardio workouts display miles goal by comparing unit type case-insensitively
- show time as full minutes when seconds are zero
- apply same fix to log details page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `pytest app_workout/tests.py` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68b727330458833291c803bf36b9bcbd